### PR TITLE
Check text length before calling Substring method

### DIFF
--- a/Models/LogItem.cs
+++ b/Models/LogItem.cs
@@ -5,7 +5,7 @@
         public string Text { get; set; }
         public string Date { get; set; }
         public string Preview {
-            get { return Text.Substring(0, 75) + "..."; }
+            get { return Text.Length > 75 ? Text.Substring(0, 75) + "..." : Text; }
         }
     }
 }


### PR DESCRIPTION
Avoid ArgumentOutOfRangeException if text length is less than 75 characters.